### PR TITLE
Fix disconnects on service updates

### DIFF
--- a/endpoint.go
+++ b/endpoint.go
@@ -103,6 +103,7 @@ func (ep *endpoint) MarshalJSON() ([]byte, error) {
 	epMap["ingressPorts"] = ep.ingressPorts
 	epMap["svcAliases"] = ep.svcAliases
 	epMap["loadBalancer"] = ep.loadBalancer
+	epMap["serviceEnabled"] = ep.serviceEnabled
 
 	return json.Marshal(epMap)
 }
@@ -221,6 +222,10 @@ func (ep *endpoint) UnmarshalJSON(b []byte) (err error) {
 	var myAliases []string
 	json.Unmarshal(ma, &myAliases)
 	ep.myAliases = myAliases
+
+	if s, ok := epMap["serviceEnabled"]; ok {
+		ep.serviceEnabled = s.(bool)
+	}
 	return nil
 }
 
@@ -245,6 +250,7 @@ func (ep *endpoint) CopyTo(o datastore.KVObject) error {
 	dstEp.svcID = ep.svcID
 	dstEp.virtualIP = ep.virtualIP
 	dstEp.loadBalancer = ep.loadBalancer
+	dstEp.serviceEnabled = ep.serviceEnabled
 
 	dstEp.svcAliases = make([]string, len(ep.svcAliases))
 	copy(dstEp.svcAliases, ep.svcAliases)
@@ -759,6 +765,13 @@ func (ep *endpoint) sbLeave(sb *sandbox, force bool, options ...EndpointOption) 
 		logrus.Warnf("Could not cleanup network resources on container %s disconnect: %v", ep.name, err)
 	}
 
+	if ep.isServiceEnabled() {
+		if e := ep.deleteDriverInfoFromCluster(); e != nil {
+			logrus.Errorf("Could not delete endpoint state for endpoint %s from cluster: %v", ep.Name(), e)
+		}
+		ep.disableService()
+	}
+
 	// Update the store about the sandbox detach only after we
 	// have completed sb.clearNetworkresources above to avoid
 	// spurious logs when cleaning up the sandbox when the daemon
@@ -766,10 +779,6 @@ func (ep *endpoint) sbLeave(sb *sandbox, force bool, options ...EndpointOption) 
 	// detach but after store has been updated.
 	if err := n.getController().updateToStore(ep); err != nil {
 		return err
-	}
-
-	if e := ep.deleteDriverInfoFromCluster(); e != nil {
-		logrus.Errorf("Could not delete endpoint state for endpoint %s from cluster: %v", ep.Name(), e)
 	}
 
 	sb.deleteHostsEntries(n.getSvcRecords(ep))

--- a/sandbox.go
+++ b/sandbox.go
@@ -682,11 +682,24 @@ func (sb *sandbox) EnableService() (err error) {
 		}
 	}()
 	for _, ep := range sb.getConnectedEndpoints() {
+		n, err := ep.getNetworkFromStore()
+		if err != nil {
+			return fmt.Errorf("failed to enable service on sandbox:%s,endpoint:%s,err: %v", sb.ID(), ep.Name(), err)
+		}
+
+		ep, err = n.getEndpointFromStore(ep.id)
+		if err != nil {
+			return fmt.Errorf("failed to get endpoint %s from store : %v", ep.Name(), err)
+		}
 		if !ep.isServiceEnabled() {
 			if err := ep.addServiceInfoToCluster(sb); err != nil {
 				return fmt.Errorf("could not update state for endpoint %s into cluster: %v", ep.Name(), err)
 			}
 			ep.enableService()
+
+			if err := n.getController().updateToStore(ep); err != nil {
+				return fmt.Errorf("failed to update store for endpoint %s", ep.Name())
+			}
 		}
 	}
 	logrus.Debugf("EnableService %s DONE", sb.containerID)
@@ -703,11 +716,27 @@ func (sb *sandbox) DisableService() (err error) {
 	}()
 	for _, ep := range sb.getConnectedEndpoints() {
 		if ep.isServiceEnabled() {
+			n, err := ep.getNetworkFromStore()
+			if err != nil {
+				logrus.Warnf("failed tp disable service on sanbox:%s,endpoint:%s,err: %v", sb.ID(), ep.Name(), err)
+				failedEps = append(failedEps, ep.Name())
+				continue
+			}
+			ep, err = n.getEndpointFromStore(ep.id)
+			if err != nil {
+				logrus.Warnf("failed to get endpoint from store : %v", err)
+				continue
+			}
 			if err := ep.deleteServiceInfoFromCluster(sb, "DisableService"); err != nil {
 				failedEps = append(failedEps, ep.Name())
 				logrus.Warnf("failed update state for endpoint %s into cluster: %v", ep.Name(), err)
 			}
 			ep.disableService()
+
+			if err := n.getController().updateToStore(ep); err != nil {
+				failedEps = append(failedEps, ep.Name())
+				logrus.Warnf("failed to update the store on disable service for ep:%s err: %v", ep.ID(), err)
+			}
 		}
 	}
 	logrus.Debugf("DisableService %s DONE", sb.containerID)


### PR DESCRIPTION
Related to moby/moby#30321, swarm removes the network as the container
is shutting down, not honouring the `stop_grace_period`.

Signed-off-by: Yarek Tyshchenko <yarek.tyshchenko@awin.com>